### PR TITLE
Create dependencies map concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "jenga"
 version = "0.1.0"
 dependencies = [
+ "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -295,6 +301,15 @@ name = "rayon"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -538,6 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
@@ -566,6 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
+"checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 authors = ["Andrea Cognolato <andrecogno@hotmail.it>"]
 
 [dependencies]
+rayon = "1.0"
+rocket = "0.3.14"
+rocket_codegen = "0.3.14"
 serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "1.0.21"
-rocket = "0.3.14"
-rocket_codegen = "0.3.14"
 
 [dependencies.rocket_contrib]
 version = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ struct Key(String, IgnoredAny, IgnoredAny);
 fn create_dependencies_map(dependencies_path: &Path) -> Result<DependeciesMap> {
     // Remeber, I've removed first and last line and then added a comma at the
     // end of the second-last
+    // Source file: https://skimdb.npmjs.com/registry/_design/app/_view/dependedUpon?reduce=false
     let file = File::open(dependencies_path)?;
 
     // Read all file lines into memory


### PR DESCRIPTION
This PR makes use of `rayon` to concurrently parse and build the dependencies map, to improve starting performance on multi-core systems. First, the whole dependencies file is loaded into memory line by line, after which each line is concurrently parsed and mapped/folded/reduced into the final `HashMap`.

Because I wanted to keep error handling as with your solution I propagated errors through the `rayon` iterators being used, to allow error handling when the concurrent operation finishes. This makes the code a bit ugly, requiring `match` blocks and such. There is one side effect with this approach, if an error occurs, it won't be returned immediately. Instead, it is returned as soon as the concurrent loading operation completes.

On my system (Intel Core i5-4670K @ 3.4Ghz) this improves the startup time about 40% (1.1s to 0.75s).
Note though, that this only improved startup times on multi-core systems.

In addition, I also added the `deps.json` source URL to the related comment in-code, which might be useful for others when taking a look in this project.

I'm not sure at all if you desire a pull request like this. I thought it would be fun though to give implementing `rayon` in this way a try, so I did. If you're running the actual server on a single-core machine, it might not be viable to implement this. Maybe you can try it out for yourself, to see the performance difference.